### PR TITLE
Make py2ju handle lists

### DIFF
--- a/src/CDSAPI.jl
+++ b/src/CDSAPI.jl
@@ -51,11 +51,11 @@ Takes a Python dictionary as string and converts it into Julia's `Dict`
 # Examples
 ```julia-repl
 julia> str = \"""{
-               "format": "zip",
-               "variable": "surface_air_temperature",
-               "product_type": "climatology",
-               "month": "08",
-               "origin": "era_interim"
+               'format': 'zip',
+               'variable': 'surface_air_temperature',
+               'product_type': 'climatology',
+               'month': '08',
+               'origin': 'era_interim',
            }\""";
 
 julia> py2ju(str)

--- a/src/CDSAPI.jl
+++ b/src/CDSAPI.jl
@@ -77,6 +77,18 @@ function py2ju(dictstr)
         # remove the comma
         dictstr_cpy = dictstr_cpy[begin:lastcomma_pos - 1] * dictstr_cpy[lastcomma_pos + 1:end]
     end
+
+    # removes trailing comma from a list
+    listend = 0
+    while true
+        listend = findnext(']', dictstr_cpy, listend + 1)
+        listend = listend === nothing ? break : listend
+        lastcomma_pos = findprev(",", dictstr_cpy, listend).start
+        if all(isspace, dictstr_cpy[lastcomma_pos+1:listend-1])
+            dictstr_cpy = dictstr_cpy[begin:lastcomma_pos - 1] * dictstr_cpy[lastcomma_pos + 1:end]
+        end
+    end
+
     return JSON.parse(dictstr_cpy)
 end
 

--- a/src/CDSAPI.jl
+++ b/src/CDSAPI.jl
@@ -79,15 +79,8 @@ function py2ju(dictstr)
     end
 
     # removes trailing comma from a list
-    listend = 0
-    while true
-        listend = findnext(']', dictstr_cpy, listend + 1)
-        listend = listend === nothing ? break : listend
-        lastcomma_pos = findprev(",", dictstr_cpy, listend).start
-        if all(isspace, dictstr_cpy[lastcomma_pos+1:listend-1])
-            dictstr_cpy = dictstr_cpy[begin:lastcomma_pos - 1] * dictstr_cpy[lastcomma_pos + 1:end]
-        end
-    end
+    rx = r",[ \n\r\t]*\]"
+    dictstr_cpy = replace(dictstr_cpy, rx => "]")
 
     return JSON.parse(dictstr_cpy)
 end


### PR DESCRIPTION
Fixes #25 

An alternate version with regex for this PR can be:
```julia
    # removes trailing comma from a list
    rx = r",[ \n\r\t]*\]"
    dictstr_cpy = replace(dictstr_cpy, rx => "]")
```
I have tested both versions. Both work perfectly.
I'm open to criticisms and more ideas :blush: 

***Side Note:** There are dozens of cases in which `py2ju` can fail, but if we are specific to CDAPI then `py2ju` will work fine.* 