### PR TITLE
Fix build error for Julia: 1.3

### DIFF
--- a/src/CDSAPI.jl
+++ b/src/CDSAPI.jl
@@ -75,7 +75,7 @@ function py2ju(dictstr)
     # if there's no pair after the last comma
     if findnext(":", dictstr_cpy, lastcomma_pos) == nothing
         # remove the comma
-        dictstr_cpy = dictstr_cpy[begin:lastcomma_pos - 1] * dictstr_cpy[lastcomma_pos + 1:end]
+        dictstr_cpy = dictstr_cpy[firstindex(dictstr_cpy):(lastcomma_pos - 1)] * dictstr_cpy[(lastcomma_pos + 1):lastindex(dictstr_cpy)]
     end
 
     # removes trailing comma from a list


### PR DESCRIPTION
This PR will fix the current build error for Julia: 1.3 and similar future build errors for lower versions too.

### The error:
```bash 
Warning: Deprecated syntax `"begin" inside indexing expression` at /home/travis/build/JuliaClimate/CDSAPI.jl/src/CDSAPI.jl:78.
└ @ ~/build/JuliaClimate/CDSAPI.jl/src/CDSAPI.jl:78
ERROR: LoadError: syntax: extra token "]" after end of expression
```

### Why this error?
See: [begin - end current and future scope](https://discourse.julialang.org/t/what-is-the-current-and-future-status-of-begin-keyword-in-indexing/13145/2?u=lakshyakhatri)

In other words, In our code when we wrote:
```julia
dictstr_cpy = dictstr_cpy[begin:lastcomma_pos - 1] * dictstr_cpy[lastcomma_pos + 1:end]
```
Julia complains, since it was expecting the syntax:
```julia
# This sub expressions must resolve to valid index or slice
array[begin <some_expression> end]

# These sub expressions must resolve to valid indices
array[begin <some_expression> end : begin <some_expression_2> end]
```

### Solution
A quick fix is to prevent using `begin` and `end` inside arrays because of the different behaviours in different versions of Julia.