### PR TITLE
reduce screen output and less polling on the server

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CDSAPI"
 uuid = "8a7b9de3-9c00-473e-88b4-7eccd7ef2fea"
 authors = ["Micky Yun Chan <michan@redhat.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -9,7 +9,7 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [compat]
-HTTP = "0.8, 0.9"
+HTTP = "0.8, 0.9, 1"
 JSON = "0.21"
 julia = "1.3"
 

--- a/src/CDSAPI.jl
+++ b/src/CDSAPI.jl
@@ -43,6 +43,12 @@ function retrieve(name, params, filename; max_sleep = 120.)
         data = JSON.parse(String(data.body))
         println("request queue status ", data["state"])
 
+        if data["state"] == "failed"
+            error("Request to dataset $name failed. Check " *
+                  "https://cds.climate.copernicus.eu/cdsapp#!/yourrequests " *
+                  "for more information (after login).")
+        end
+
         sleep_seconds = min(1.5 * sleep_seconds,max_sleep)
         if data["state"] != "completed"
             sleep(sleep_seconds)

--- a/src/CDSAPI.jl
+++ b/src/CDSAPI.jl
@@ -8,13 +8,16 @@ export
     py2ju
 
 """
-    retrieve(name, params, filename)
+    retrieve(name, params, filename; max_sleep = 120.)
 
 Retrieves data for `name` from the Climate Data Store
 with the specified `params` and stores it in the current
 directory as `filename`.
+
+The client periodically requests the status of the retrieve request.
+`max_sleep` is the maximum time (in seconds) between the status updates.
 """
-function retrieve(name, params, filename)
+function retrieve(name, params, filename; max_sleep = 120.)
     creds = Dict()
     open(joinpath(homedir(),".cdsapirc")) do f
         for line in readlines(f)
@@ -33,10 +36,17 @@ function retrieve(name, params, filename)
 
     resp_dict = JSON.parse(String(response.body))
     data = Dict("state" => "queued")
+    sleep_seconds = 1.
+
     while data["state"] != "completed"
         data = HTTP.request("GET", creds["url"] * "/tasks/" * string(resp_dict["request_id"]),  ["Authorization" => apikey])
         data = JSON.parse(String(data.body))
         println("request queue status ", data["state"])
+
+        sleep_seconds = min(1.5 * sleep_seconds,max_sleep)
+        if data["state"] != "completed"
+            sleep(sleep_seconds)
+        end
     end
 
     HTTP.download(data["location"], filename)


### PR DESCRIPTION
This PR address issue https://github.com/JuliaClimate/CDSAPI.jl/issues/40 and allows for HTTP v1.

I noticed that for HTTP v1, the option `verbose = 1`  now includes some additional output not present in HTTP v0.9 of this type:

```
┌ LogLevel(-1001): POST /api/v2/resources/reanalysis-era5-pressure-levels-monthly-means HTTP/1.1           
└ @ HTTP.StreamRequest ~/.julia/packages/HTTP/S5kNN/src/clientlayers/StreamRequest.jl:24
┌ Debug: called process()
│   code = :end
│   input_size = 297
│   output_size = 16384
│   input_delta = 297
│   output_delta = 433
└ @ TranscodingStreams ~/.julia/packages/TranscodingStreams/IVlnc/src/stream.jl:638
``` 

This output disappears when the `verbose = 1` is dropped. I did not change this  in this PR.

https://github.com/JuliaClimate/CDSAPI.jl/blob/e8dd56fcad4ae113e0d7ddebcd52cf336003f552/src/CDSAPI.jl#L32
