### PR TITLE
Test with new julia LTS 1.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.10'
           - '1'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Configure API Keys 🔒
         shell: bash
         run: |
-          echo ${{ secrets.CDSAPI_URL }} > ~/.cdsapirc
-          echo ${{ secrets.CDSAPI_KEY }} >> ~/.cdsapirc
+          echo "url: ${{ secrets.CDSAPI_URL }}" > ~/.cdsapirc
+          echo "key: ${{ secrets.CDSAPI_KEY }}" >> ~/.cdsapirc
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1


### PR DESCRIPTION
Github actions are running with the new API (#46) and new secrets. 
For the secrets however it's important to store it in the following way:
CDSAPI_URL = "url: https://cds.climate.copernicus.eu/api"
CDSAPI_KEY = "key: XXXXXXXXXXXXXXXXXXXXX"

I just considered that we should update the tests to the new LTS version of julia

Fix #46 