### PR TITLE
way less spammy errors on bad requests.

### DIFF
--- a/src/CDSAPI.jl
+++ b/src/CDSAPI.jl
@@ -34,7 +34,7 @@ function retrieve(name, params, filename; wait=1.0)
                 throw(ArgumentError("""
                 The requested dataset '$name' was not found
                 """))
-            elseif 500 > e.status >= 400
+            elseif 400 ≤ e.status < 500
                 throw(ArgumentError("""
                 The request is in a bad format:
                 $params

--- a/src/CDSAPI.jl
+++ b/src/CDSAPI.jl
@@ -32,7 +32,7 @@ function retrieve(name, params, filename; wait=1.0)
         if e isa HTTP.StatusError
             if e.status == 404
                 throw(ArgumentError("""
-                The requested dataset '$name' was not found
+                The requested dataset $name was not found.
                 """))
             elseif 400 ≤ e.status < 500
                 throw(ArgumentError("""

--- a/src/CDSAPI.jl
+++ b/src/CDSAPI.jl
@@ -22,11 +22,21 @@ function retrieve(name, params, filename; wait=1.0)
         end
     end
 
-    response = HTTP.request("POST",
-        creds["url"] * "/retrieve/v1/processes/$name/execute",
-        ["PRIVATE-TOKEN" => creds["key"]],
-        body=JSON.json(Dict("inputs" => params))
-    )
+    try
+        response = HTTP.request("POST",
+            creds["url"] * "/retrieve/v1/processes/$name/execute",
+            ["PRIVATE-TOKEN" => creds["key"]],
+            body=JSON.json(Dict("inputs" => params))
+        )
+    catch e
+        if e isa HTTP.StatusError && e.status == 422
+            throw(ArgumentError("""
+            The request body provided is ill formed.
+            """))
+        end
+        throw(e)
+    end
+
     body = JSON.parse(String(response.body))
     data = Dict("status" => "queued")
 

--- a/src/CDSAPI.jl
+++ b/src/CDSAPI.jl
@@ -29,10 +29,17 @@ function retrieve(name, params, filename; wait=1.0)
             body=JSON.json(Dict("inputs" => params))
         )
     catch e
-        if e isa HTTP.StatusError && e.status == 422
-            throw(ArgumentError("""
-            The request body provided is ill formed.
-            """))
+        if e isa HTTP.StatusError
+            if e.status == 404
+                throw(ArgumentError("""
+                The requested dataset '$name' was not found
+                """))
+            elseif 500 > e.status >= 400
+                throw(ArgumentError("""
+                The request is in a bad format:
+                $params
+                """))
+            end
         end
         throw(e)
     end

--- a/test/retrieve.jl
+++ b/test/retrieve.jl
@@ -1,20 +1,6 @@
 @testset "Retrieve" begin
     datadir = joinpath(@__DIR__, "data")
 
-    @testset "Bad requests errors are catched" begin
-
-        bad_request = """{
-            "this": "is",
-            "a": "bad",
-            "re": ["quest"]
-        }"""
-        dataset = "reanalysis-era5-single-levels"
-        bad_dataset = "bad-dataset"
-
-        @test_throws ArgumentError CDSAPI.retrieve(dataset, bad_request, "unreachable")
-        @test_throws ArgumentError CDSAPI.retrieve(bad_dataset, bad_request, "unreachable")
-    end
-
     @testset "ERA5 monthly preasure data" begin
         filepath = joinpath(datadir, "era5.grib")
         response = CDSAPI.retrieve("reanalysis-era5-pressure-levels-monthly-means",
@@ -78,5 +64,18 @@
         # cleanup
         rm(filepath)
         rm(ewq_file)
+    end
+
+    @testset "Bad requests errors are catched" begin
+        goodname = "reanalysis-era5-single-levels"
+        badname = "bad-dataset"
+        badrequest = """{
+            "this": "is",
+            "a": "bad",
+            "re": ["quest"]
+        }"""
+
+        @test_throws ArgumentError CDSAPI.retrieve(goodname, badrequest, "unreachable")
+        @test_throws ArgumentError CDSAPI.retrieve(badname, badrequest, "unreachable")
     end
 end

--- a/test/retrieve.jl
+++ b/test/retrieve.jl
@@ -1,6 +1,20 @@
 @testset "Retrieve" begin
     datadir = joinpath(@__DIR__, "data")
 
+    @testset "Bad requests errors are catched" begin
+
+        bad_request = """{
+            "this": "is",
+            "a": "bad",
+            "re": ["quest"]
+        }"""
+        dataset = "reanalysis-era5-single-levels"
+        bad_dataset = "bad-dataset"
+
+        @test_throws ArgumentError CDSAPI.retrieve(dataset, bad_request, "unreachable")
+        @test_throws ArgumentError CDSAPI.retrieve(bad_dataset, bad_request, "unreachable")
+    end
+
     @testset "ERA5 monthly preasure data" begin
         filepath = joinpath(datadir, "era5.grib")
         response = CDSAPI.retrieve("reanalysis-era5-pressure-levels-monthly-means",


### PR DESCRIPTION
This is rather minor and left for last.

It simply adds a check to grab the error in case of a badly formatted request that cuts down on the spam that HTTP.jl does, and provides a more descriptive error other than "422: unprocessable event"