### PR TITLE
Slightly better logging experience.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,12 @@ authors = ["Micky Yun Chan <michan@redhat.com> and contributors"]
 version = "2.0.3"
 
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [compat]
+Dates = "1.11.0"
 HTTP = "1"
 JSON = "0.21"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [compat]
-Dates = "1.11.0"
+Dates = "1.11"
 HTTP = "1"
 JSON = "0.21"
 julia = "1"

--- a/src/CDSAPI.jl
+++ b/src/CDSAPI.jl
@@ -89,6 +89,8 @@ function retrieve(name, params::AbstractDict, filename; wait=1.0)
         ["PRIVATE-TOKEN" => creds["key"]]
     )
     body = JSON.parse(String(response.body))
+
+    print("\e[1K\e[0E")
     HTTP.download(body["asset"]["value"]["href"], filename)
 
     return data

--- a/src/CDSAPI.jl
+++ b/src/CDSAPI.jl
@@ -55,17 +55,15 @@ function retrieve(name, params::AbstractDict, filename; wait=1.0)
 
     laststatus = nothing
     while data["status"] != "successful"
-
         data = HTTP.request("GET", endpoint,
             ["PRIVATE-TOKEN" => creds["key"]]
         )
         data = JSON.parse(String(data.body))
 
         if data["status"] != laststatus
-            @info "$(Dates.format(now(), dateformat"HH:MM:SS")) - CDS request" dataset=name status=data["status"]
+            @info "CDS status update on $(now())" dataset = name status = data["status"]
             laststatus = data["status"]
         end
-
 
         if data["status"] == "failed"
             throw(ErrorException("""

--- a/src/CDSAPI.jl
+++ b/src/CDSAPI.jl
@@ -61,7 +61,7 @@ function retrieve(name, params::AbstractDict, filename; wait=1.0)
         data = JSON.parse(String(data.body))
 
         if data["status"] != laststatus
-            @info "CDS status update on $(now())" dataset = name status = data["status"]
+            @info "CDS request update on $(now())" dataset = name status = data["status"]
             laststatus = data["status"]
         end
 

--- a/src/CDSAPI.jl
+++ b/src/CDSAPI.jl
@@ -62,11 +62,8 @@ function retrieve(name, params::AbstractDict, filename; wait=1.0)
         data = JSON.parse(String(data.body))
 
         if data["status"] != laststatus
-            print("\e[1K\e[0E") # erase terminal line and reset cursor
             @info "$(Dates.format(now(), dateformat"HH:MM:SS")) - CDS request" dataset=name status=data["status"]
             laststatus = data["status"]
-        else
-            print('.')
         end
 
 
@@ -90,7 +87,6 @@ function retrieve(name, params::AbstractDict, filename; wait=1.0)
     )
     body = JSON.parse(String(response.body))
 
-    print("\e[1K\e[0E")
     HTTP.download(body["asset"]["value"]["href"], filename)
 
     return data


### PR DESCRIPTION
While testing for the previous PRs, I got a bit annoyed by the repeated spam of the same message at every status update.

This PR changes the logging to print a new message only when the status actually changes, adds a timestamp and a
simple indicator of progress.
An example of complete output is:
```julia
┌ Info: 14:32:11 - CDS request                                    
│   dataset = "reanalysis-era5-pressure-levels-monthly-means"     
└   status = "accepted"                                           
┌ Info: 14:32:18 - CDS request
│   dataset = "reanalysis-era5-pressure-levels-monthly-means"     
└   status = "successful"                                         
┌ Info: Downloading
│   source = "https://object-store.os-api.cci2.ecmwf.int:443/cci2-prod-cache/1c5003f9dc140530e360d2824bcca486.grib"
│   dest = "C:\\Users\\User\\Dev\\+Julia\\CDSAPI.jl\\test\\data\\era5.grib"
│   progress = 1.0                                                
│   time_taken = "0.27 s"                                         
│   time_remaining = "0.0 s"                                      
│   average_speed = "7.417 MiB/s"                                 
│   downloaded = "1.980 MiB"                                      
│   remaining = "0 bytes"                                         
└   total = "1.980 MiB"        
```

While in between updates an example output is:
```julia
┌ Info: 14:32:11 - CDS request                                    
│   dataset = "reanalysis-era5-pressure-levels-monthly-means"     
└   status = "accepted"
...... # adds a `.` every wait interval
```