### PR TITLE
Allow JSON v1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,4 +23,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [targets]
-test = ["Test", "GRIB", "ZipFile", "NetCDF"]
+test = ["Test", "GRIB", "NetCDF", "ZipFile"]

--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,8 @@ ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
 [compat]
 Dates = "1.10"
 HTTP = "1"
-JSON = "0.21, 1"
-ScopedValues = "1.3.0"
+JSON = "1"
+ScopedValues = "1.3"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CDSAPI"
 uuid = "8a7b9de3-9c00-473e-88b4-7eccd7ef2fea"
 authors = ["Micky Yun Chan <michan@redhat.com> and contributors"]
-version = "2.2.1"
+version = "2.2.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -12,7 +12,7 @@ ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
 [compat]
 Dates = "1.10"
 HTTP = "1"
-JSON = "0.21"
+JSON = "0.21, 1"
 ScopedValues = "1.3.0"
 julia = "1.10"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using CDSAPI
-using ZipFile
 using GRIB, NetCDF
+using ZipFile
+using JSON
 
 using Test
 
@@ -24,7 +25,7 @@ datadir = joinpath(@__DIR__, "data")
             filename
         )
 
-        @test typeof(response) <: Dict
+        @test typeof(response) <: JSON.Object
         @test isfile(filename)
 
         GribFile(filename) do datafile
@@ -54,7 +55,7 @@ datadir = joinpath(@__DIR__, "data")
             filename
         )
 
-        @test typeof(response) <: Dict
+        @test typeof(response) <: JSON.Object
         @test isfile(filename)
 
         # extract contents


### PR DESCRIPTION
[CompatHelper is disabled](https://github.com/JuliaClimate/CDSAPI.jl/actions/workflows/CompatHelper.yml), so here's a manual PR.  I can't test this because I don't have the credentials, but reading the [JSON.jl migration guide](https://juliaio.github.io/JSON.jl/stable/migrate/#Migration-guide-from-pre-1.0-1.0), there shouldn't be significant breaking changes for the use of this package: only `JSON.json` and `JSON.parse` are used, the former should be basically unaffected as far this package is concerned, the latter has the output type changed from `Dict` to `JSON.Object`, but that's still an `AbstractDict`, so hopefully nothing needs to be changed here.

A new version would be welcome after this PR is merged (I'm also bumping the version number here).